### PR TITLE
Fix Next.js build alias resolution

### DIFF
--- a/__tests__/tsconfig.test.ts
+++ b/__tests__/tsconfig.test.ts
@@ -1,0 +1,12 @@
+import fs from 'fs'
+import path from 'path'
+
+describe('tsconfig path aliases', () => {
+  test('baseUrl and paths are configured', () => {
+    const tsconfigPath = path.join(__dirname, '..', 'tsconfig.json')
+    const raw = fs.readFileSync(tsconfigPath, 'utf-8')
+    const json = JSON.parse(raw)
+    expect(json.compilerOptions.baseUrl).toBe('.')
+    expect(json.compilerOptions.paths['@/*'][0]).toBe('./src/*')
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "baseUrl": ".",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
## Summary
- configure `baseUrl` in `tsconfig.json` so `@` alias resolves in production
- add regression test for tsconfig path alias settings

## Testing
- `npm test -- --coverage` *(fails: 14 failed, 25 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6846f8365ef48328b46cba7a1d4e67f9