### PR TITLE
Auth reset: redirect + docs + env template

### DIFF
--- a/config/production.env.template
+++ b/config/production.env.template
@@ -5,13 +5,15 @@
 # Copy this file to .env.production and fill in the actual values.
 # 
 # Created: 2025-01-16
-# Last Modified: 2025-01-16
-# Last Modified Summary: Initial production environment template
+# Last Modified: 2025-08-25
+# Last Modified Summary: Set canonical NEXT_PUBLIC_SITE_URL to https://www.orangecat.ch and added notes
 
 # ==================== REQUIRED PRODUCTION VARIABLES ====================
 
 # Site Configuration
-NEXT_PUBLIC_SITE_URL=https://orangecat.bitcoin
+# IMPORTANT: Must EXACTLY match Supabase Auth site_url domain and the allow-listed redirect origins
+# Recommended canonical production domain: https://www.orangecat.ch
+NEXT_PUBLIC_SITE_URL=https://www.orangecat.ch
 NEXT_PUBLIC_SITE_NAME=OrangeCat
 NODE_ENV=production
 


### PR DESCRIPTION
- Redirect reset error params from / to /auth/reset-password in middleware
- Document recovery flow and production redirect configuration
- Set canonical NEXT_PUBLIC_SITE_URL in production env template

Please verify Supabase Auth -> URL configuration matches NEXT_PUBLIC_SITE_URL (recommend https://www.orangecat.ch) and Additional Redirect URLs include both www and apex reset paths.