### PR TITLE
Password reset UX: always land on reset page; correct production redirect

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+export default function PrivacyPage() {
+  return (
+    <div className="min-h-screen bg-white">
+      <div className="max-w-3xl mx-auto px-4 py-12">
+        <h1 className="text-3xl font-bold text-gray-900 mb-4">Privacy Policy</h1>
+        <p className="text-gray-600 mb-6">We respect your privacy. This page will be updated with our detailed policy.</p>
+      </div>
+    </div>
+  )
+}
+
+

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+export default function TermsPage() {
+  return (
+    <div className="min-h-screen bg-white">
+      <div className="max-w-3xl mx-auto px-4 py-12">
+        <h1 className="text-3xl font-bold text-gray-900 mb-4">Terms of Service</h1>
+        <p className="text-gray-600 mb-6">Our terms of service will be published here.</p>
+      </div>
+    </div>
+  )
+}
+
+

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -24,7 +24,7 @@ export async function middleware(request: NextRequest) {
   // Supabase may redirect with only error params when the link is expired/invalid
   const hasAuthErrors = url.searchParams.has('error') || url.searchParams.has('error_code') || url.hash.includes('error=')
   
-  if ((hasResetTokens && isRecoveryType || hasAuthErrors) && url.pathname === '/') {
+  if ((hasResetTokens && isRecoveryType || hasAuthErrors) && url.pathname !== '/auth/reset-password') {
     // Redirect to reset password page while preserving all query params and hash
     const resetUrl = new URL('/auth/reset-password', request.url)
     

--- a/src/services/supabase/auth/index.ts
+++ b/src/services/supabase/auth/index.ts
@@ -136,11 +136,13 @@ export async function signUp({ email, password, emailRedirectTo }: SignUpRequest
       setTimeout(() => reject(new Error('Registration request timed out')), 25000);
     });
 
+    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.orangecat.ch'
+
     const authPromise = supabase.auth.signUp({
       email,
       password,
       options: {
-        emailRedirectTo: emailRedirectTo || process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+        emailRedirectTo: emailRedirectTo || siteUrl
       }
     });
 
@@ -226,8 +228,11 @@ export async function resetPassword({ email }: PasswordResetRequest): Promise<{ 
     logAuth('Attempting password reset', { email })
     
     // Use canonical www domain to avoid losing hash/query tokens on redirect
+    // Important: This URL MUST match exactly what's configured in Supabase Dashboard
     const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.orangecat.ch'
     const redirectUrl = `${siteUrl}/auth/reset-password`
+    
+    logAuth('Using redirect URL for password reset', { redirectUrl })
     
     const { error } = await supabase.auth.resetPasswordForEmail(email, {
       redirectTo: redirectUrl
@@ -238,14 +243,15 @@ export async function resetPassword({ email }: PasswordResetRequest): Promise<{ 
       return { error }
     }
 
-    logAuth('Password reset email sent', { email, redirectUrl })
+    logAuth('Password reset email sent successfully', { email, redirectUrl })
     return { error: null }
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error)
     logger.error('Unexpected error during password reset', {
-      error: error instanceof Error ? error.message : String(error),
+      error: errorMessage,
       email
     })
-    return { error: error as AuthError }
+    return { error: { message: errorMessage, name: 'ResetError' } as AuthError }
   }
 }
 


### PR DESCRIPTION
- Signup emailRedirectTo now defaults to production site URL
- Middleware redirects any recovery/error token URL to /auth/reset-password from any path, preserving query + hash
- Goal: clicking email link always lands on the password reset page directly, with tokens, no homepage bounce

After deploy: trigger a reset, click email link, verify immediate reset page with session or clear expired message.